### PR TITLE
draft for pre-/post-backup hooks/commands

### DIFF
--- a/command.go
+++ b/command.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/pkg/errors"
+	"os/exec"
+	"strings"
+)
+
+func executeCommand(command string) (*string, error) {
+	trimmed := strings.TrimSpace(command)
+	parts := strings.Split(trimmed, " ")
+	cmd := exec.Command(parts[0], parts[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.Errorf("%s: %v, %s", command, err.Error(), string(out))
+	}
+	stdout := string(out)
+	return &stdout, nil
+}
+
+func (b *backup) executePreCommand() (*string, error) {
+	return executeCommand(b.PreCommand)
+}
+
+func (b *backup) executePostCommand() (*string, error) {
+	return executeCommand(b.PostCommand)
+}


### PR DESCRIPTION
Hi @Southclaws, just like @DrMurx requested in https://github.com/Southclaws/restic-robot/issues/3 i needed that feature as well (just to test some things).

So, this is my quick and dirty attempt...

Some notes:
- The split/trim/"parsing" in https://github.com/opthomas-prime/restic-robot/blob/master/command.go#L9 is pretty basic... E.g. commands with quotes will fail
- Execution time of the commands is not measured independently