### PR TITLE
Don't combine -q and -v

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func (b *backup) Run() {
 		}
 	}
 
-	args := []string{"backup", "-q", "-v"}
+	args := []string{"backup"}
 	args = append(args, strings.Split(b.Args, " ")...)
 
 	cmd := exec.Command("restic", args...)


### PR DESCRIPTION
restic seems to not like being called with both `-v` and `-q`, this showed up in my restic-robot logs:

```
"Fatal: --quiet and --verbose cannot be specified at the same time",
"stacktrace":
  main.(*backup).Run
restic-robot/main.go:109
  main.main
restic-robot/main.go:78
  runtime.main
usr/local/go/src/runtime/proc.go:204
```
While I found [this](https://github.com/restic/restic/issues/1796) related issue from 2018 I can only reproduce the issue manually with the new restic v0.12.0 so I suspect something changed there. 

From what I have read in the restic issues I assume `-q -v` was used to hide the interactive restic statusbar while still getting the stats at the end? At least in my quick test with the current restic version this behavior seems to be the default when being called from a non-interactive context.