### PR TITLE
modify line endings for logging on Windows

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"runtime"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -18,6 +19,11 @@ func init() {
 
 	config = zap.NewProductionConfig()
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+
+	if runtime.GOOS == "windows" {
+		// modify line endings to the Windows-specific version
+		config.EncoderConfig.LineEnding = "\r\n"
+	}
 
 	if debug != "0" && debug != "" {
 		config.Level = zap.NewAtomicLevel()


### PR DESCRIPTION
Configure `zap` to use `\r\n` as line ending on Windows systems. This simplifies log output, especially if Windows-specific tools like Notepad are used.