### PR TITLE
Use JSON output from Restic commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
+	"encoding/json"
+	"io"
 	"os/exec"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -35,10 +37,7 @@ type backup struct {
 }
 
 var (
-	matchExists     = regexp.MustCompile(`.*already (exists|initialized).*`)
-	matchFileStats  = regexp.MustCompile(`Files:\s*([0-9.]*) new,\s*([0-9.]*) changed,\s*([0-9.]*) unmodified`)
-	matchAddedBytes = regexp.MustCompile(`Added to the (repo|repository): ([0-9.]+) (\w+)`)
-	matchProcessed  = regexp.MustCompile(`processed ([0-9.]*) files, ([0-9.]+) (\w+)`)
+	matchExists = regexp.MustCompile(`.*already (exists|initialized).*`)
 )
 
 type stats struct {
@@ -46,8 +45,8 @@ type stats struct {
 	filesChanged    int
 	filesUnmodified int
 	filesProcessed  int
-	bytesAdded      int
-	bytesProcessed  int
+	bytesAdded      int64
+	bytesProcessed  int64
 }
 
 func main() {
@@ -121,7 +120,7 @@ func (b *backup) Run() {
 	}
 
 	// execute restic backup
-	cmd := exec.Command("restic", append([]string{"backup"}, parseArg(b.Args)...)...)
+	cmd := exec.Command("restic", append([]string{"backup", "--json"}, parseArg(b.Args)...)...)
 	errbuf := bytes.NewBuffer(nil)
 	outbuf := bytes.NewBuffer(nil)
 	cmd.Stderr = errbuf
@@ -148,7 +147,7 @@ func (b *backup) Run() {
 
 	d := time.Since(startTime)
 
-	statistics, err := extractStats(outbuf.String())
+	statistics, err := extractJsonStats(outbuf)
 	if err != nil {
 		logger.Warn("failed to extract statistics from command output",
 			zap.Error(err))
@@ -160,8 +159,8 @@ func (b *backup) Run() {
 		zap.Int("filesChanged", statistics.filesChanged),
 		zap.Int("filesUnmodified", statistics.filesUnmodified),
 		zap.Int("filesProcessed", statistics.filesProcessed),
-		zap.Int("bytesAdded", statistics.bytesAdded),
-		zap.Int("bytesProcessed", statistics.bytesProcessed),
+		zap.Int64("bytesAdded", statistics.bytesAdded),
+		zap.Int64("bytesProcessed", statistics.bytesProcessed),
 	)
 
 	// indicate backup success
@@ -177,51 +176,49 @@ func (b *backup) Run() {
 	b.bytesProcessed.Observe(float64(statistics.bytesProcessed))
 }
 
-func extractStats(s string) (result stats, err error) {
-	fileStats := matchFileStats.FindAllStringSubmatch(s, -1)
-	if len(fileStats[0]) != 4 {
-		err = errors.Errorf("matchFileStats expected 4, got %d", len(fileStats[0]))
-		return
-	}
-	result.filesNew, _ = strconv.Atoi(fileStats[0][1])        //nolint:errcheck
-	result.filesChanged, _ = strconv.Atoi(fileStats[0][2])    //nolint:errcheck
-	result.filesUnmodified, _ = strconv.Atoi(fileStats[0][3]) //nolint:errcheck
+func extractJsonStats(outbuf *bytes.Buffer) (result stats, err error) {
+	reader := bufio.NewReader(outbuf)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			logger.Error("error reading output buffer", zap.Error(err))
+			return result, err
+		}
 
-	addedBytes := matchAddedBytes.FindAllStringSubmatch(s, -1)
-	if len(addedBytes[0]) != 3 && len(addedBytes[0]) != 4 {
-		err = errors.Errorf("matchAddedBytes expected 3, got %d", len(addedBytes[0]))
-		return
-	}
-	amount, _ := strconv.ParseFloat(addedBytes[0][1], 64) //nolint:errcheck
-	// restic doesn't use a comma to denote thousands
-	amount *= 1000
-	result.bytesAdded = convert(int(amount), addedBytes[0][2])
+		var msg BackupMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			logger.Error("error unmarshalling JSON", zap.ByteString("line", line), zap.Error(err))
+			return result, err
+		}
 
-	filesProcessed := matchProcessed.FindAllStringSubmatch(s, -1)
-	if len(filesProcessed[0]) != 4 {
-		err = errors.Errorf("filesProcessed expected 4, got %d", len(filesProcessed[0]))
-		return
+		switch msg.MessageType {
+		case "summary":
+			var summary BackupSummaryMessage
+			if err := json.Unmarshal(line, &summary); err != nil {
+				logger.Error("error unmarshalling summary message", zap.ByteString("line", line), zap.Error(err))
+				return result, err
+			}
+			result.filesNew = summary.FilesNew
+			result.filesChanged = summary.FilesChanged
+			result.filesUnmodified = summary.FilesUnmodified
+			result.filesProcessed = summary.TotalFilesProcessed
+			result.bytesAdded = summary.DataAdded
+			result.bytesProcessed = summary.TotalBytesProcessed
+		case "status":
+			logger.Debug("received status update", zap.ByteString("line", line))
+		case "error":
+			var errorMsg BackupErrorMessage
+			if err := json.Unmarshal(line, &errorMsg); err != nil {
+				logger.Error("error unmarshalling error message", zap.ByteString("line", line), zap.Error(err))
+			} else {
+				logger.Error("backup error", zap.String("error", errorMsg.Error), zap.String("during", errorMsg.During), zap.String("item", errorMsg.Item))
+			}
+		}
 	}
-	result.filesProcessed, _ = strconv.Atoi(filesProcessed[0][1]) //nolint:errcheck
-	amount, _ = strconv.ParseFloat(filesProcessed[0][2], 64)      //nolint:errcheck
-	amount *= 1000
-	result.bytesProcessed = convert(int(amount), filesProcessed[0][3])
-
-	return
-}
-
-func convert(b int, unit string) (result int) {
-	switch unit {
-	case "TiB":
-		result = b * (1 << 40)
-	case "GiB":
-		result = b * (1 << 30)
-	case "MiB":
-		result = b * (1 << 20)
-	case "KiB":
-		result = b * (1 << 10)
-	}
-	return
+	return result, nil
 }
 
 // Ensure will create a repository if it does not already exist

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -8,38 +9,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_extractStats(t *testing.T) {
+func Test_extractJsonStats(t *testing.T) {
 	tests := []struct {
 		input      string
 		wantResult stats
 	}{
-		{`open repository
-lock repository
-load index files
-using parent snapshot 38401629
-start scan on [./test/]
-start backup on [./test/]
-scan finished in 0.797s: 58 files, 97.870 MiB
-
-Files:          56 new,     2 changed,     2 unmodified
-Dirs:            0 new,     0 changed,     0 unmodified
-Data Blobs:     35 new
-Tree Blobs:      1 new
-Added to the repo: 169.009 KiB
-
-processed 58 files, 97.870 MiB in 0:00
-snapshot c7693989 saved`, stats{
+		{`{"message_type":"summary","files_new":56,"files_changed":2,"files_unmodified":2,"dirs_new":0,"dirs_changed":0,"dirs_unmodified":0,"data_blobs":35,"tree_blobs":1,"data_added":169009,"total_files_processed":58,"total_bytes_processed":102624133120}
+`, stats{
 			filesNew:        56,
 			filesChanged:    2,
 			filesUnmodified: 2,
 			filesProcessed:  58,
-			bytesAdded:      173065216,
+			bytesAdded:      169009,
 			bytesProcessed:  102624133120,
 		}},
 	}
 	for ii, tt := range tests {
 		t.Run(fmt.Sprint(ii), func(t *testing.T) {
-			gotResult, err := extractStats(tt.input)
+			inputBuffer := bytes.NewBufferString(tt.input)
+			gotResult, err := extractJsonStats(inputBuffer)
 			if err != nil {
 				t.Error(err)
 			}

--- a/restic_types.go
+++ b/restic_types.go
@@ -57,3 +57,10 @@ type BackupSummaryMessage struct {
 	TotalDuration       float64 `json:"total_duration"`
 	SnapshotID          string  `json:"snapshot_id"`
 }
+
+// InitMessage represents the summary of `restic init`.
+type InitMessage struct {
+	MessageType string `json:"message_type"`
+	ID          string `json:"id"`
+	Repository  string `json:"repository"`
+}

--- a/restic_types.go
+++ b/restic_types.go
@@ -1,0 +1,59 @@
+package main
+
+// Restic Types from JSON output: https://restic.readthedocs.io/en/stable/075_scripting.html#json-output
+
+// BackupMessage represents a general message from Restic backup, with a MessageType for type assertion.
+type BackupMessage struct {
+	MessageType string `json:"message_type"`
+}
+
+// BackupStatusMessage represents the "status" messages emitted during backup operations.
+type BackupStatusMessage struct {
+	MessageType      string   `json:"message_type"`
+	SecondsElapsed   float64  `json:"seconds_elapsed"`
+	SecondsRemaining float64  `json:"seconds_remaining,omitempty"`
+	PercentDone      float64  `json:"percent_done"`
+	TotalFiles       int      `json:"total_files"`
+	FilesDone        int      `json:"files_done"`
+	TotalBytes       int64    `json:"total_bytes"`
+	BytesDone        int64    `json:"bytes_done"`
+	ErrorCount       int      `json:"error_count"`
+	CurrentFiles     []string `json:"current_files,omitempty"`
+}
+
+// BackupErrorMessage represents the "error" messages that provide details on errors encountered.
+type BackupErrorMessage struct {
+	MessageType string `json:"message_type"`
+	Error       string `json:"error"`
+	During      string `json:"during"`
+	Item        string `json:"item"`
+}
+
+// BackupVerboseStatusMessage provides detailed progress updates, including specifics about files being backed up.
+type BackupVerboseStatusMessage struct {
+	MessageType  string  `json:"message_type"`
+	Action       string  `json:"action"`
+	Item         string  `json:"item"`
+	Duration     float64 `json:"duration"`
+	DataSize     int64   `json:"data_size"`
+	MetadataSize int64   `json:"metadata_size"`
+	TotalFiles   int     `json:"total_files"`
+}
+
+// BackupSummaryMessage represents the summary of a completed backup operation.
+type BackupSummaryMessage struct {
+	MessageType         string  `json:"message_type"`
+	FilesNew            int     `json:"files_new"`
+	FilesChanged        int     `json:"files_changed"`
+	FilesUnmodified     int     `json:"files_unmodified"`
+	DirsNew             int     `json:"dirs_new"`
+	DirsChanged         int     `json:"dirs_changed"`
+	DirsUnmodified      int     `json:"dirs_unmodified"`
+	DataBlobs           int     `json:"data_blobs"`
+	TreeBlobs           int     `json:"tree_blobs"`
+	DataAdded           int64   `json:"data_added"`
+	TotalFilesProcessed int     `json:"total_files_processed"`
+	TotalBytesProcessed int64   `json:"total_bytes_processed"`
+	TotalDuration       float64 `json:"total_duration"`
+	SnapshotID          string  `json:"snapshot_id"`
+}


### PR DESCRIPTION
This PR:

* Changes from parsing the stdout line via regex to using Restic's "Scripting" JSON output feature: https://restic.readthedocs.io/en/stable/075_scripting.html#json-output
* Changes `bytesAdded` and `bytesProcessed` to int64 type
* There is a status message that is emitted as backups happen that I've put in the debug log: https://github.com/Southclaws/restic-robot/compare/master...rjocoleman:restic-robot:json-output?expand=1#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R210
* This should be backwards compatible, but I've had to change the test to match the changes output. 

I could not reconcile how `bytesAdded` was being converted in the test: https://github.com/Southclaws/restic-robot/compare/master...rjocoleman:restic-robot:json-output?expand=1#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL36

Hopefully this should be better insulated from changes to the output than parsing stdout!

This starts down the path of adding more instrumentation via open telemetry https://github.com/open-telemetry/opentelemetry-go or similar to emit metrics and logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced backup statistics parsing to support JSON format.
- **Refactor**
	- Transitioned from text-based to JSON-based parsing for backup statistics.
	- Improved accuracy of byte count variables by changing their type to `int64`.
- **Bug Fixes**
	- Updated error handling and logging for more robust repository initialization.
- **Documentation**
	- Updated test documentation to reflect changes in statistics parsing method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->