### PR TITLE
Add ERROR_COMMAND to run if Restic backup fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Environment variables:
 - `PROMETHEUS_ADDRESS`: metrics host:port
 - `PRE_COMMAND`: A shell command to run before a backup starts
 - `POST_COMMAND`: A shell command to run if the backup completes successfully
-- `ERROR_COMMAND`: A shell command to run if the backup errors
+- `ERROR_COMMAND`: A shell command to run if the backup errors. For example, to send a notification to a Slack channel on backup failure, you could set it to a curl command that posts to your Slack webhook.
 - `TRIGGER_ENDPOINT`: manual trigger endpoint
 
 Prometheus metrics:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Environment variables:
 - `PROMETHEUS_ADDRESS`: metrics host:port
 - `PRE_COMMAND`: A shell command to run before a backup starts
 - `POST_COMMAND`: A shell command to run if the backup completes successfully
+- `ERROR_COMMAND`: A shell command to run if the backup errors
 - `TRIGGER_ENDPOINT`: manual trigger endpoint
 
 Prometheus metrics:

--- a/command.go
+++ b/command.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/pkg/errors"
 	"os/exec"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 func executeCommand(command string) (*string, error) {
@@ -24,4 +25,8 @@ func (b *backup) executePreCommand() (*string, error) {
 
 func (b *backup) executePostCommand() (*string, error) {
 	return executeCommand(b.PostCommand)
+}
+
+func (b *backup) executeErrorCommand() (*string, error) {
+	return executeCommand(b.ErrorCommand)
 }

--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func (b *backup) Run() {
 
 	// execute pre-command (if configured)
 	if len(b.PreCommand) > 0 {
+		logger.Debug("executing pre-command", zap.String("command", b.PreCommand))
 		if stdout, err := b.executePreCommand(); err != nil {
 			logger.Error("failed to execute pre-command: " + err.Error())
 			return
@@ -137,7 +138,9 @@ func (b *backup) Run() {
 		b.backupsFailed.Inc()
 		b.backupsTotal.Inc()
 
+		// execute error-command (if configured)
 		if len(b.ErrorCommand) > 0 {
+			logger.Debug("executing error-command", zap.String("command", b.ErrorCommand))
 			if stdout, err := b.executeErrorCommand(); err != nil {
 				logger.Error("failed to execute error-command: " + err.Error())
 			} else if stdout != nil {
@@ -148,7 +151,9 @@ func (b *backup) Run() {
 		return
 	}
 
+	// execute post-command (if configured)
 	if len(b.PostCommand) > 0 {
+		logger.Debug("executing post-command", zap.String("command", b.PostCommand))
 		if stdout, err := b.executePostCommand(); err != nil {
 			logger.Error("failed to execute post-command: " + err.Error())
 			return


### PR DESCRIPTION
This PR:

* Adds handling for ENV var `ERROR_COMMAND`, if present this will be run on a non-zero exit from `restic`

Resolves #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced an option to specify a shell command (`ERROR_COMMAND`) to be executed automatically after a backup failure. This enhances error handling capabilities.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->