### PR TITLE
Add goreleaser and github action for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: './go.mod'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ github.actor }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: cardinalby/export-env-action@v2
+        with:
+          envFile: '.env'
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 restic-robot
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ archives:
 
 dockers:
   - image_templates:
-      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-amd64"
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-amd64-restic-{{.Env.RESTIC_VERSION}}"
     use: buildx
     dockerfile: goreleaser.dockerfile
     build_flag_templates:
@@ -40,9 +40,10 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=RESTIC_VERSION={{.Env.RESTIC_VERSION}}"
       - "--platform=linux/amd64"
   - image_templates:
-      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-arm64v8"
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-arm64v8-restic-{{.Env.RESTIC_VERSION}}"
     use: buildx
     goarch: arm64
     dockerfile: goreleaser.dockerfile
@@ -51,17 +52,18 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--build-arg=RESTIC_VERSION={{.Env.RESTIC_VERSION}}"
       - "--platform=linux/arm64/v8"
 
 docker_manifests:
-  - name_template: "ghcr.io/southclaws/restic-robot:{{ .Version }}"
+  - name_template: "ghcr.io/southclaws/restic-robot:{{ .Version }}-restic-{{.Env.RESTIC_VERSION}}"
     image_templates:
-      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-amd64"
-      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-arm64v8"
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-amd64-restic-{{.Env.RESTIC_VERSION}}"
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-arm64v8-restic-{{.Env.RESTIC_VERSION}}"
   - name_template: "ghcr.io/southclaws/restic-robot:latest"
     image_templates:
-      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-amd64"
-      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-arm64v8"
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-amd64-restic-{{.Env.RESTIC_VERSION}}"
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-arm64v8-restic-{{.Env.RESTIC_VERSION}}"
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 1
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+dockers:
+  - image_templates:
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: goreleaser.dockerfile
+    build_flag_templates:
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-arm64v8"
+    use: buildx
+    goarch: arm64
+    dockerfile: goreleaser.dockerfile
+    build_flag_templates:
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/arm64/v8"
+
+docker_manifests:
+  - name_template: "ghcr.io/southclaws/restic-robot:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-amd64"
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-arm64v8"
+  - name_template: "ghcr.io/southclaws/restic-robot:latest"
+    image_templates:
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-amd64"
+      - "ghcr.io/southclaws/restic-robot:{{ .Version }}-arm64v8"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG RESTIC_VERSION
+
 FROM golang:alpine AS builder
 
 WORKDIR /restic-robot
@@ -9,7 +11,7 @@ RUN apk add musl-dev
 RUN go mod tidy
 RUN go build
 
-FROM restic/restic AS runner
+FROM restic/restic:${RESTIC_VERSION:?} AS runner
 
 COPY --from=builder /restic-robot/restic-robot /usr/bin/restic-robot
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RESTIC_VERSION
+ARG RESTIC_VERSION=latest
 
 FROM golang:alpine AS builder
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a small and simple wrapper application for [Restic](https://github.com/r
 
 ## Usage
 
-Just `go build` and run it, or, if you're into Docker, `southclaws/restic-robot`.
+Just `go build` and run it, or, if you're into Docker, `ghcr.io/southclaws/restic-robot`.
 
 Environment variables:
 

--- a/go.mod
+++ b/go.mod
@@ -1,24 +1,29 @@
 module github.com/Southclaws/restic-robot
 
+go 1.22.1
+
+require (
+	github.com/joho/godotenv v1.3.0
+	github.com/kelseyhightower/envconfig v1.3.0
+	github.com/pkg/errors v0.8.0
+	github.com/prometheus/client_golang v0.9.0
+	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
+	github.com/stretchr/testify v1.2.2
+	go.uber.org/zap v1.9.1
+)
+
 require (
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.1.1 // indirect
 	github.com/golang/protobuf v1.2.0 // indirect
-	github.com/joho/godotenv v1.3.0
-	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v0.9.0
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect
 	github.com/prometheus/common v0.0.0-20181020173914-7e9e6cabbd39 // indirect
 	github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d // indirect
-	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
-	github.com/stretchr/testify v1.2.2
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
-	go.uber.org/zap v1.9.1
 	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 )

--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -1,5 +1,6 @@
 ## Dedicated Dockerfile for goreleaser, the goreleaser built binary are copied to the restic image
 # https://goreleaser.com/errors/docker-build/#docker-build-failures
-FROM restic/restic
+ARG RESTIC_VERSION
+FROM restic/restic:${RESTIC_VERSION:?} AS runner
 COPY restic-robot /usr/bin/restic-robot
 ENTRYPOINT ["/usr/bin/restic-robot"]

--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -1,0 +1,5 @@
+## Dedicated Dockerfile for goreleaser, the goreleaser built binary are copied to the restic image
+# https://goreleaser.com/errors/docker-build/#docker-build-failures
+FROM restic/restic
+COPY restic-robot /usr/bin/restic-robot
+ENTRYPOINT ["/usr/bin/restic-robot"]

--- a/makefile
+++ b/makefile
@@ -1,3 +1,6 @@
+include .env
+export
+
 local: fast
 	./restic-robot
 
@@ -6,5 +9,6 @@ fast:
 
 build:
 	docker build \
+		--build-arg RESTIC_VERSION=$(RESTIC_VERSION) \
 		-t ghcr.io/southclaws/restic-robot \
 		.

--- a/makefile
+++ b/makefile
@@ -6,5 +6,5 @@ fast:
 
 build:
 	docker build \
-		-t southclaws/restic-robot \
+		-t ghcr.io/southclaws/restic-robot \
 		.


### PR DESCRIPTION
This PR:

* Adds goreleaser to build dist artefacts and multi-platform docker image
* Adds a Github action to run goreleaser when a tag is pushed and create a release + changelog
* Updates the docker image location in the README to ghcr
* This happens when a tag is pushed to `master` branch and that tag is used as the version number. (This is not integrated into the app itself.)

An example of how this would look is here: 

* https://github.com/rjocoleman/restic-robot/releases/tag/v0.0.2
* https://github.com/rjocoleman/restic-robot/pkgs/container/restic-robot

**Questions:**

* I think it would be preferable to use a version tag that matches the restic version e.g. `v0.16.4`, and update the dockerfiles to use this version too. This would also be what's tagged in docker. I'll make another commit to support that workflow which can be omitted if this project prefers different version numbers. (*Update:* added in 12c7d77594f390b45ec26cea88b9152ed30cf4b9)

Resolves #17 

**Important:**

This won't build without the fix to `bytesAdded` and `bytesProcessed` to change them to `int64` rather than `int`, this is in my PR #23 or the diff below (I can add to this PR or open another if needed without the JSON output changes).

```diff
diff --git a/main.go b/main.go
index f2ec4e9..0ea5eac 100644
--- a/main.go
+++ b/main.go
@@ -46,8 +46,8 @@ type stats struct {
 	filesChanged    int
 	filesUnmodified int
 	filesProcessed  int
- bytesAdded      int
- bytesProcessed  int
+	bytesAdded      int64
+	bytesProcessed  int64
 }
 
 func main() {
@@ -160,8 +160,8 @@ func (b *backup) Run() {
 		zap.Int("filesChanged", statistics.filesChanged),
 		zap.Int("filesUnmodified", statistics.filesUnmodified),
 		zap.Int("filesProcessed", statistics.filesProcessed),
- zap.Int("bytesAdded", statistics.bytesAdded),
- zap.Int("bytesProcessed", statistics.bytesProcessed),
+		zap.Int64("bytesAdded", statistics.bytesAdded),
+		zap.Int64("bytesProcessed", statistics.bytesProcessed),
 	)
 
 	// indicate backup success
@@ -195,7 +195,7 @@ func extractStats(s string) (result stats, err error) {
 	amount, _ := strconv.ParseFloat(addedBytes[0][1], 64) //nolint:errcheck
 	// restic doesn't use a comma to denote thousands
 	amount *= 1000
- result.bytesAdded = convert(int(amount), addedBytes[0][2])
+	result.bytesAdded = convert(int64(amount), addedBytes[0][2])
 
 	filesProcessed := matchProcessed.FindAllStringSubmatch(s, -1)
 	if len(filesProcessed[0]) != 4 {
@@ -205,12 +205,12 @@ func extractStats(s string) (result stats, err error) {
 	result.filesProcessed, _ = strconv.Atoi(filesProcessed[0][1]) //nolint:errcheck
 	amount, _ = strconv.ParseFloat(filesProcessed[0][2], 64)      //nolint:errcheck
 	amount *= 1000
- result.bytesProcessed = convert(int(amount), filesProcessed[0][3])
+	result.bytesProcessed = convert(int64(amount), filesProcessed[0][3])
 
 	return
 }
 
-func convert(b int, unit string) (result int) {
+func convert(b int64, unit string) (result int64) {
 	switch unit {
 	case "TiB":
 		result = b * (1 << 40)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Introduced a GitHub Actions workflow for automating the release process.
    - Added support for building and packaging with GoReleaser, including configurations for various operating systems and Docker.
- **Documentation**
    - Updated Docker image references in the README.
- **Chores**
    - Updated `.gitignore` to exclude `dist/` directory.
    - Updated Docker image tag in the makefile.
    - Added a dedicated Dockerfile for integrating `goreleaser` with the `restic` image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->